### PR TITLE
v1.0.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG ?= v1.0.9
+TAG ?= v1.0.10
 AWS_ECR_REGISTRY=public.ecr.aws/logzio
 
 .PHONY: build-push-images-multiarch-ecr

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ make push-images
   - Improve `nodejs` instrumentation:
     - Use `BatchSpanProcessor`
     - Disable `@opentelemetry/instrumentation-fs` To improve performance and avoid high memory usage on startup (https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1344)
-    - Fix bug to delete `OTEL_RESOURCE_ATTRIBUTES` in rollback (nodejs)
+    - Fix bug to delete `OTEL_RESOURCE_ATTRIBUTES` on rollback (nodejs)
 * v1.0.9
     - Add `easy.connect.version` resource attributes to spans
     - Enrich detection pod logs

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ make push-images
   - Improve `nodejs` instrumentation:
     - Use `BatchSpanProcessor`
     - Disable `@opentelemetry/instrumentation-fs` To improve performance and avoid high memory usage on startup (https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1344)
+    - Fix bug to delete `OTEL_RESOURCE_ATTRIBUTES` in rollback (nodejs)
 * v1.0.9
     - Add `easy.connect.version` resource attributes to spans
     - Enrich detection pod logs

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ make push-images
 
 ## Change log
 
+* v1.0.10
+  - Improve `nodejs` instrumentation:
+    - Use `BatchSpanProcessor`
+    - Disable `@opentelemetry/instrumentation-fs` To improve performance and avoid high memory usage on startup (https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1344)
 * v1.0.9
     - Add `easy.connect.version` resource attributes to spans
     - Enrich detection pod logs

--- a/agents/nodejs/src/autoinstrumentation.ts
+++ b/agents/nodejs/src/autoinstrumentation.ts
@@ -1,12 +1,11 @@
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { BasicTracerProvider, SimpleSpanProcessor} from '@opentelemetry/sdk-trace-base';
+import { BasicTracerProvider, BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { Resource } from "@opentelemetry/resources";
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 
 const process = require("process");
-
 
 console.log("Instrumenting Node.js application");
 console.log("Active config: ", process.env.OTEL_SERVICE_NAME, process.env.OTEL_TRACES_EXPORTER, process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, process.env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL);
@@ -24,28 +23,36 @@ const provider = new BasicTracerProvider({
 });
 
 console.log("Adding OTLP exporter");
-// export spans to opentelemetry collector
-provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+// export spans to opentelemetry collector using BatchSpanProcessor for better performance and efficiency
+provider.addSpanProcessor(new BatchSpanProcessor(exporter));
 provider.register();
 
 console.log("Registering Node.js auto-instrumentations");
 const sdk = new NodeSDK({
     traceExporter: exporter,
-    instrumentations: [getNodeAutoInstrumentations()],
+    instrumentations: [getNodeAutoInstrumentations({
+        '@opentelemetry/instrumentation-fs': {
+            enabled: false,
+        }
+    })],
 });
 
-sdk.start()
+sdk.start();
 console.log("Tracing initialized");
 
-process.on("SIGTERM", () => {
-    sdk
-        .shutdown()
-        .then(
-            () => console.log("SDK shut down successfully"),
-            (err) => console.log("Error shutting down SDK", err)
-        )
-        .finally(() => process.exit(0));
-});
+const gracefulShutdown = () => {
+    sdk.shutdown().then(
+        () => {
+            console.log("SDK shut down successfully");
+            process.exit(0);
+        },
+        (err) => {
+            console.error("Error shutting down SDK", err);
+            process.exit(1);
+        }
+    );
+};
 
-
-
+// Handle various termination signals
+process.on("SIGTERM", gracefulShutdown);
+process.on("SIGINT", gracefulShutdown);

--- a/instrumentor/patch/nodejs.go
+++ b/instrumentor/patch/nodejs.go
@@ -198,7 +198,7 @@ func (n *nodeJsPatcher) UnPatch(podSpec *v1.PodTemplateSpec) error {
 	for i, container := range podSpec.Spec.Containers {
 		var newEnv []v1.EnvVar
 		for _, envVar := range container.Env {
-			if envVar.Name != NodeIPEnvName && envVar.Name != nodeEnvNodeDebug && envVar.Name != nodeEnvTraceExporter && envVar.Name != nodeEnvEndpoint && envVar.Name != nodeEnvTraceProtocol && envVar.Name != nodeEnvServiceName {
+			if envVar.Name != NodeIPEnvName && envVar.Name != resourceAttrEnv && envVar.Name != nodeEnvNodeDebug && envVar.Name != nodeEnvTraceExporter && envVar.Name != nodeEnvEndpoint && envVar.Name != nodeEnvTraceProtocol && envVar.Name != nodeEnvServiceName {
 				if envVar.Name == nodeEnvNodeOptions {
 					envVar.Value = strings.Replace(envVar.Value, fmt.Sprintf("--require %s/autoinstrumentation.js", nodeMountPath), "", -1)
 					// Remove the node options if it's empty

--- a/instrumentor/patch/python.go
+++ b/instrumentor/patch/python.go
@@ -204,7 +204,7 @@ func (p *pythonPatcher) UnPatch(podSpec *v1.PodTemplateSpec) error {
 	for i, container := range podSpec.Spec.Containers {
 		var newEnv []v1.EnvVar
 		for _, env := range container.Env {
-			if env.Name != NodeIPEnvName && env.Name != PodNameEnvVName && env.Name != envLogCorrelation && env.Name != "PYTHONPATH" && env.Name != "OTEL_EXPORTER_OTLP_ENDPOINT" && env.Name != "OTEL_RESOURCE_ATTRIBUTES" && env.Name != envOtelTracesExporter && env.Name != envOtelExporterOTLPTracesProtocol && env.Name != envOtelExporterOTLPMetricsProtocol && env.Name != envOtelMetricsExporter && env.Name != httpProtoProtocol {
+			if env.Name != NodeIPEnvName && env.Name != PodNameEnvVName && env.Name != envLogCorrelation && env.Name != "PYTHONPATH" && env.Name != "OTEL_EXPORTER_OTLP_ENDPOINT" && env.Name != resourceAttrEnv && env.Name != envOtelTracesExporter && env.Name != envOtelExporterOTLPTracesProtocol && env.Name != envOtelExporterOTLPMetricsProtocol && env.Name != envOtelMetricsExporter && env.Name != httpProtoProtocol {
 				newEnv = append(newEnv, env)
 			}
 		}

--- a/instrumentor/patch/root.go
+++ b/instrumentor/patch/root.go
@@ -39,7 +39,7 @@ const (
 	nodeInitContainerName        = "copy-nodejs-agent"
 	javaInitContainerName        = "copy-java-agent"
 	dotnetInitContainerName      = "copy-dotnet-agent"
-	easyConnectVersion           = "v1.0.9"
+	easyConnectVersion           = "v1.0.10"
 	resourceAttrEnv              = "OTEL_RESOURCE_ATTRIBUTES"
 	resourceAttr                 = "easy.connect.version=%s"
 )


### PR DESCRIPTION
Improve `nodejs` instrumentation:
  - Use `BatchSpanProcessor`
  - Disable `@opentelemetry/instrumentation-fs` To improve performance and avoid high memory usage on startup (https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1344)
