### PR TITLE
v1.0.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG ?= v1.0.10
+TAG ?= v1.0.11
 AWS_ECR_REGISTRY=public.ecr.aws/logzio
 
 .PHONY: build-push-images-multiarch-ecr

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ make push-images
 
 ## Change log
 
+* v1.0.11
+  - Update `python` instrumentation:
+    - update base image: `python:3.10-alpine` -> `python:3.11-alpine` (https://github.com/open-telemetry/opentelemetry-operator/issues/1515)
+  - Create `dotnet` agent version with instrumentation `v0.5.0` (tag: `logzio/otel-agent-dotnet:v1.0.11-0.5.0`)
 * v1.0.10
   - Improve `nodejs` instrumentation:
     - Use `BatchSpanProcessor`

--- a/agents/python/Dockerfile
+++ b/agents/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine AS build
+FROM python:3.11-alpine AS build
 
 ADD requirements.txt .
 RUN mkdir autoinstrumentation && pip install --target autoinstrumentation -r requirements.txt


### PR DESCRIPTION
* v1.0.11
  - Update `python` instrumentation:
    - update base image: `python:3.10-alpine` -> `python:3.11-alpine` (https://github.com/open-telemetry/opentelemetry-operator/issues/1515)
  - Create `dotnet` agent version with instrumentation `v0.5.0` (tag: `logzio/otel-agent-dotnet:v1.0.11-0.5.0`)